### PR TITLE
refactor: replace modal on profile settings

### DIFF
--- a/components/profile/Tabs/General.tsx
+++ b/components/profile/Tabs/General.tsx
@@ -7,7 +7,7 @@ import { useUpdateProfileMutation } from '@/assets/api/user/profileQueryApi'
 import { Loading } from '@/components/common/Loaders/Loading'
 import { axiosAPI } from '@/assets/api/api'
 import { Button } from '@/@ui/ui-kit/Button/Button'
-import { Modal } from '@/components/common/Modal/Modal'
+import Modal from '@/@ui/ui-kit/Modal/Modal'
 import { useTranslation } from 'react-i18next'
 import { TextArea } from '@/@ui/ui-kit/Textareas/Textarea'
 import { MainDatePicker, saveToArray } from '@/@ui/ui-kit/DatePicker/DatePicker'
@@ -139,10 +139,12 @@ const General: React.FC<GeneralType> = ({ userProfile }) => {
       </div>
       {isModalOpen && (
         <Modal
-          title={translate('modal_error_title')}
-          content={translate('modal_error_content')}
-          onClose={() => setIsModalOpen(false)}
-        />
+        title={translate('modal_error_title')}
+        children={translate('modal_error_content')}
+        setActive={() => setIsModalOpen(false)}
+        active={isModalOpen}
+        close
+      />
       )}
     </>
   )


### PR DESCRIPTION
replace old modal with a new one in order to prevent date picker overlapping
![chrome_fuOCjly9Cn](https://github.com/FightersForJustice/inctagram/assets/79192846/13fde785-4f5f-4357-bdfb-1af722368b60)
